### PR TITLE
Refactor: needless clones of RecursiveSnark inputs

### DIFF
--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -76,8 +76,8 @@ fn bench_compressed_snark(c: &mut Criterion) {
       let res = recursive_snark.verify(
         &pp,
         i + 1,
-        vec![<G1 as Group>::Scalar::from(2u64)],
-        vec![<G2 as Group>::Scalar::from(2u64)],
+        &vec![<G1 as Group>::Scalar::from(2u64)][..],
+        &vec![<G2 as Group>::Scalar::from(2u64)][..],
       );
       assert!(res.is_ok());
     }

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -71,8 +71,8 @@ fn bench_recursive_snark(c: &mut Criterion) {
       let res = recursive_snark.verify(
         &pp,
         i + 1,
-        vec![<G1 as Group>::Scalar::from(2u64)],
-        vec![<G2 as Group>::Scalar::from(2u64)],
+        &vec![<G1 as Group>::Scalar::from(2u64)],
+        &vec![<G2 as Group>::Scalar::from(2u64)],
       );
       assert!(res.is_ok());
     }
@@ -99,8 +99,8 @@ fn bench_recursive_snark(c: &mut Criterion) {
           .verify(
             black_box(&pp),
             black_box(num_warmup_steps),
-            black_box(vec![<G1 as Group>::Scalar::from(2u64)]),
-            black_box(vec![<G2 as Group>::Scalar::from(2u64)]),
+            black_box(&vec![<G1 as Group>::Scalar::from(2u64)]),
+            black_box(&vec![<G2 as Group>::Scalar::from(2u64)]),
           )
           .is_ok());
       });

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -247,7 +247,7 @@ fn main() {
     // verify the recursive SNARK
     println!("Verifying a RecursiveSNARK...");
     let start = Instant::now();
-    let res = recursive_snark.verify(&pp, num_steps, z0_primary.clone(), z0_secondary.clone());
+    let res = recursive_snark.verify(&pp, num_steps, &z0_primary, &z0_secondary);
     println!(
       "RecursiveSNARK::verify: {:?}, took {:?}",
       res.is_ok(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,12 +201,16 @@ where
     z0_primary: Vec<G1::Scalar>,
     z0_secondary: Vec<G2::Scalar>,
   ) -> Self {
+    // Expected outputs of the two circuits
+    let zi_primary = c_primary.output(&z0_primary);
+    let zi_secondary = c_secondary.output(&z0_secondary);
+
     // base case for the primary
     let mut cs_primary: SatisfyingAssignment<G1> = SatisfyingAssignment::new();
     let inputs_primary: NovaAugmentedCircuitInputs<G2> = NovaAugmentedCircuitInputs::new(
       scalar_as_base::<G1>(pp.digest),
       G1::Scalar::ZERO,
-      z0_primary.clone(),
+      z0_primary,
       None,
       None,
       None,
@@ -230,7 +234,7 @@ where
     let inputs_secondary: NovaAugmentedCircuitInputs<G1> = NovaAugmentedCircuitInputs::new(
       pp.digest,
       G2::Scalar::ZERO,
-      z0_secondary.clone(),
+      z0_secondary,
       None,
       None,
       Some(u_primary.clone()),
@@ -261,10 +265,6 @@ where
     let r_W_secondary = RelaxedR1CSWitness::<G2>::default(&pp.r1cs_shape_secondary);
     let r_U_secondary =
       RelaxedR1CSInstance::<G2>::default(&pp.ck_secondary, &pp.r1cs_shape_secondary);
-
-    // Outputs of the two circuits thus far
-    let zi_primary = c_primary.output(&z0_primary);
-    let zi_secondary = c_secondary.output(&z0_secondary);
 
     if zi_primary.len() != pp.F_arity_primary || zi_secondary.len() != pp.F_arity_secondary {
       panic!("Invalid step length");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,8 +401,8 @@ where
     &self,
     pp: &PublicParams<G1, G2, C1, C2>,
     num_steps: usize,
-    z0_primary: Vec<G1::Scalar>,
-    z0_secondary: Vec<G2::Scalar>,
+    z0_primary: &[G1::Scalar],
+    z0_secondary: &[G2::Scalar],
   ) -> Result<(Vec<G1::Scalar>, Vec<G2::Scalar>), NovaError> {
     // number of steps cannot be zero
     if num_steps == 0 {
@@ -430,7 +430,7 @@ where
       );
       hasher.absorb(pp.digest);
       hasher.absorb(G1::Scalar::from(num_steps as u64));
-      for e in &z0_primary {
+      for e in z0_primary {
         hasher.absorb(*e);
       }
       for e in &self.zi_primary {
@@ -444,7 +444,7 @@ where
       );
       hasher2.absorb(scalar_as_base::<G1>(pp.digest));
       hasher2.absorb(G2::Scalar::from(num_steps as u64));
-      for e in &z0_secondary {
+      for e in z0_secondary {
         hasher2.absorb(*e);
       }
       for e in &self.zi_secondary {
@@ -902,8 +902,8 @@ mod tests {
     let res = recursive_snark.verify(
       &pp,
       num_steps,
-      vec![<G1 as Group>::Scalar::ZERO],
-      vec![<G2 as Group>::Scalar::ZERO],
+      &vec![<G1 as Group>::Scalar::ZERO][..],
+      &vec![<G2 as Group>::Scalar::ZERO][..],
     );
     assert!(res.is_ok());
   }
@@ -961,8 +961,8 @@ mod tests {
       let res = recursive_snark.verify(
         &pp,
         i + 1,
-        vec![<G1 as Group>::Scalar::ONE],
-        vec![<G2 as Group>::Scalar::ZERO],
+        &vec![<G1 as Group>::Scalar::ONE][..],
+        &vec![<G2 as Group>::Scalar::ZERO][..],
       );
       assert!(res.is_ok());
     }
@@ -971,8 +971,8 @@ mod tests {
     let res = recursive_snark.verify(
       &pp,
       num_steps,
-      vec![<G1 as Group>::Scalar::ONE],
-      vec![<G2 as Group>::Scalar::ZERO],
+      &vec![<G1 as Group>::Scalar::ONE][..],
+      &vec![<G2 as Group>::Scalar::ZERO][..],
     );
     assert!(res.is_ok());
 
@@ -1048,8 +1048,8 @@ mod tests {
     let res = recursive_snark.verify(
       &pp,
       num_steps,
-      vec![<G1 as Group>::Scalar::ONE],
-      vec![<G2 as Group>::Scalar::ZERO],
+      &vec![<G1 as Group>::Scalar::ONE][..],
+      &vec![<G2 as Group>::Scalar::ZERO][..],
     );
     assert!(res.is_ok());
 
@@ -1142,8 +1142,8 @@ mod tests {
     let res = recursive_snark.verify(
       &pp,
       num_steps,
-      vec![<G1 as Group>::Scalar::ONE],
-      vec![<G2 as Group>::Scalar::ZERO],
+      &vec![<G1 as Group>::Scalar::ONE][..],
+      &vec![<G2 as Group>::Scalar::ZERO][..],
     );
     assert!(res.is_ok());
 
@@ -1319,7 +1319,7 @@ mod tests {
     }
 
     // verify the recursive SNARK
-    let res = recursive_snark.verify(&pp, num_steps, z0_primary.clone(), z0_secondary.clone());
+    let res = recursive_snark.verify(&pp, num_steps, &z0_primary, &z0_secondary);
     assert!(res.is_ok());
 
     // produce the prover and verifier keys for compressed snark
@@ -1390,8 +1390,8 @@ mod tests {
     let res = recursive_snark.verify(
       &pp,
       num_steps,
-      vec![<G1 as Group>::Scalar::ONE],
-      vec![<G2 as Group>::Scalar::ZERO],
+      &vec![<G1 as Group>::Scalar::ONE][..],
+      &vec![<G2 as Group>::Scalar::ZERO][..],
     );
     assert!(res.is_ok());
 


### PR DESCRIPTION
removes a couple unneeded clones in circuit inputs